### PR TITLE
Double  starts two X servers wasting resources.

### DIFF
--- a/src/etc/init.d/selenium-server
+++ b/src/etc/init.d/selenium-server
@@ -91,7 +91,7 @@ do_start()
     
     # --user in daemon doesn't prepare environment variables like HOME, USER, LOGNAME or USERNAME,
     # so we let su do so for us now
-    $SU -l $SELENIUM_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- $XVFB $XVFB $XVFB_ARGS $JAVA $JAVA_ARGS -jar $SELENIUM_JAR $SELENIUM_ARGS" || return 2
+    $SU -l $SELENIUM_USER --shell=/bin/bash -c "$DAEMON $DAEMON_ARGS -- $XVFB $XVFB_ARGS $JAVA $JAVA_ARGS -jar $SELENIUM_JAR $SELENIUM_ARGS" || return 2
 }
 
 #


### PR DESCRIPTION
running the run-xvfb twice causes two X servers to run, one on :99 and one on :100